### PR TITLE
fix "exports is not defined" error

### DIFF
--- a/generators/app/templates/webpack/development.js
+++ b/generators/app/templates/webpack/development.js
@@ -32,6 +32,7 @@ module.exports = {
             babelrc: false,
             presets: [
               ['env', {
+                modules: false,
                 targets: {
                   browsers: [
                     'last 2 versions',


### PR DESCRIPTION
With babel-preset-env, you must pass `{ modules: false }`.  I think this has something to do with letting babel know that you're using es6 modules (?)